### PR TITLE
Minor improvements and bug fixes

### DIFF
--- a/inc/types/string.h
+++ b/inc/types/string.h
@@ -110,7 +110,7 @@ CharString CharString_createNull();
 
 CharString CharString_createConstRefAuto(const C8 *ptr, U64 maxSize);		//Auto detect end (up to maxSize chars)
 
-CharString CharString_createConstRefCStr(const C8 *ptr);						//Only use this if string is created safely (null terminator)
+CharString CharString_createConstRefCStr(const C8 *ptr);					//Only use this if string is created safely (null terminator)
 CharString CharString_createRefAuto(C8 *ptr, U64 maxSize);					//Auto detect end (up to maxSize chars)
 
 //hasNullAfterSize is true if the size given excludes the null terminator (e.g. ptr[size] == '\0').

--- a/src/types/string.c
+++ b/src/types/string.c
@@ -73,6 +73,14 @@ Bool CharString_isValidFileName(CharString str) {
 	for(U64 i = 0; i < CharString_length(str); ++i)
 		if(!C8_isValidFileName(str.ptr[i]))
 			return false;
+
+	//Trailing or leading space is illegal
+
+	if(CharString_endsWith(str, ' ', EStringCase_Sensitive))
+		return false;
+
+	if(CharString_startsWith(str, ' ', EStringCase_Sensitive))
+		return false;
 	
 	//Validation to make sure we're not using weird legacy MS DOS keywords
 	//Because these will not be writable correctly!
@@ -2657,6 +2665,14 @@ Error CharString_formatVariadic(Allocator alloc, CharString *result, const C8 *f
 
 	if(len < 0)
 		return Error_stderr(0);
+
+	if (result->ptr)
+		return Error_invalidOperation(0);
+
+	if (len == 0) {
+		*result = CharString_createNull();
+		return Error_none();
+	}
 
 	Error err = CharString_create('\0', (U64) len, alloc, result);
 

--- a/tools/inc/cli.h
+++ b/tools/inc/cli.h
@@ -51,6 +51,8 @@ Bool CLI_profileCRC32C(ParsedArgs args);
 Bool CLI_profileSHA256(ParsedArgs args);
 Bool CLI_profileAES256(ParsedArgs args);
 
+Bool CLI_helpOperation(ParsedArgs args);
+
 Bool CLI_inspectHeader(ParsedArgs args);
 Bool CLI_inspectData(ParsedArgs args);
 

--- a/tools/inc/operations.h
+++ b/tools/inc/operations.h
@@ -155,13 +155,19 @@ typedef enum EOperation {
 
 	EOperation_Package,
 
-	EOperation_LicenseShow,
+	EOperation_InfoLicense,
+	EOperation_InfoAbout,
 
 	EOperation_ProfileCast,
 	EOperation_ProfileRNG,
 	EOperation_ProfileCRC32C,
 	EOperation_ProfileSHA256,
 	EOperation_ProfileAES256,
+
+	EOperation_HelpCategories,
+	EOperation_HelpOperations,
+	EOperation_HelpOperation,
+	EOperation_HelpFormat,
 
 	EOperation_Invalid
 
@@ -172,8 +178,9 @@ typedef enum EOperationCategory {
 	EOperationCategory_File,
 	EOperationCategory_Hash,
 	EOperationCategory_Rand,
-	EOperationCategory_License,
+	EOperationCategory_Info,
 	EOperationCategory_Profile,
+	EOperationCategory_Help,
 	EOperationCategory_End,
 	EOperationCategory_Start = EOperationCategory_File
 } EOperationCategory;

--- a/tools/src/operations.c
+++ b/tools/src/operations.c
@@ -24,14 +24,18 @@
 #include "platforms/log.h"
 #include "cli.h"
 
-Bool CLI_license(ParsedArgs args) {
+Bool CLI_info(ParsedArgs args) {
 
 	args;
 
 	Log_debugLn(
+
 		"OxC3 (Oxsomi core 3), a general framework and toolset for cross platform applications.\n"
-		"Copyright (C) 2023 Oxsomi / Nielsbishere (Niels Brunekreef)\n"
-		"\n"
+		"Copyright (C) 2023 Oxsomi / Nielsbishere (Niels Brunekreef)"
+		"%s",
+
+		args.operation != EOperation_InfoLicense ? "" :
+		"\n\n"
 		"This program is free software: you can redistribute it and/or modify\n"
 		"it under the terms of the GNU General Public License as published by\n"
 		"the Free Software Foundation, either version 3 of the License, or\n"
@@ -70,8 +74,8 @@ const C8 *EOperationHasParameter_names[] = {
 
 const C8 *EOperationHasParameter_descriptions[] = {
 	"File format",
-	"Input file/folder (relative)",
-	"Output file/folder (relative)",
+	"Input string or path (relative)",
+	"Output path (relative)",
 	"Encryption key (32-byte hex)",
 	"Split by character (defaulted to newline)",
 	"Number of elements",
@@ -130,16 +134,18 @@ const C8 *EOperationCategory_names[] = {
 	"file",
 	"hash",
 	"rand",
-	"license",
-	"profile"
+	"info",
+	"profile",
+	"help"
 };
 
 const C8 *EOperationCategory_description[] = {
 	"File utilities such as file conversions, encryption, compression, etc.",
 	"Converting a file or string to a hash.",
 	"Generating random data.",
-	"Information about the tool license.",
-	"Profiles operations on the current system."
+	"Information about the tool.",
+	"Profiles operations on the current system.",
+	"Help about the instructions in the tool."
 };
 
 Operation Operation_values[EOperation_Invalid];
@@ -358,14 +364,26 @@ void Operations_init() {
 
 	//License for the tool
 
-	Operation_values[EOperation_LicenseShow] = (Operation) { 
+	Operation_values[EOperation_InfoLicense] = (Operation) { 
 
-		.category = EOperationCategory_License, 
+		.category = EOperationCategory_Info, 
 
-		.name = "show", 
+		.name = "license", 
 		.desc = "Shows the license.", 
 
-		.func = &CLI_license,
+		.func = &CLI_info,
+
+		.isFormatLess = true
+	};
+
+	Operation_values[EOperation_InfoAbout] = (Operation) { 
+
+		.category = EOperationCategory_Info, 
+
+		.name = "about", 
+		.desc = "Shows information about the tool.", 
+
+		.func = &CLI_info,
 
 		.isFormatLess = true
 	};
@@ -430,6 +448,62 @@ void Operations_init() {
 		.func = &CLI_profileAES256,
 
 		.isFormatLess = true
+	};
+
+	//Help operations
+
+	Operation_values[EOperation_HelpCategories] = (Operation) { 
+
+		.category = EOperationCategory_Help, 
+
+		.name = "categories", 
+		.desc = "Help to see all categories.", 
+
+		.func = &CLI_helpOperation,
+
+		.isFormatLess = true
+	};
+
+	Operation_values[EOperation_HelpOperations] = (Operation) { 
+
+		.category = EOperationCategory_Help, 
+
+		.name = "operations", 
+		.desc = "Help to see all operations in the category mentioned by -i.", 
+
+		.func = &CLI_helpOperation,
+
+		.isFormatLess = true,
+
+		.requiredParameters = EOperationHasParameter_Input
+	};
+
+	Operation_values[EOperation_HelpOperation] = (Operation) { 
+
+		.category = EOperationCategory_Help, 
+
+		.name = "operation", 
+		.desc = "Help to see all information about the operation mentioned by -i (category:operation or category).", 
+
+		.func = &CLI_helpOperation,
+
+		.isFormatLess = true,
+
+		.requiredParameters = EOperationHasParameter_Input
+	};
+
+	Operation_values[EOperation_HelpFormat] = (Operation) { 
+
+		.category = EOperationCategory_Help, 
+
+		.name = "format", 
+		.desc = "Help to see all information about the format mentioned by -i (category:operation:format).", 
+
+		.func = &CLI_helpOperation,
+
+		.isFormatLess = true,
+
+		.requiredParameters = EOperationHasParameter_Input
 	};
 }
 


### PR DESCRIPTION
Fixed a crash in format (Log_debugLn, etc.) if size was 0. Fixed trailing/leading spaces being accepted as valid files. Renamed OxC3 license show command to info license and added info about for only the about section. Added help categories, help operations, help operation and help format to allow an easier workflow to get help about commands (though this is still builtin with the normal way as well). These commands all work the same, but they have an explanation of how each sub function of the same function should work since it allows differen types of help.